### PR TITLE
Adding Git To APT Install

### DIFF
--- a/provision-os.sh
+++ b/provision-os.sh
@@ -27,7 +27,7 @@ apt-get update -yqq
 apt-get full-upgrade -yqq
 apt-get autoremove -yqq
 apt-get autoclean -yqq
-apt-get install -yqq vim lvm2 openssh-server raspberrypi-kernel-headers samba samba-common-bin tmate sysstat
+apt-get install -yqq vim lvm2 openssh-server raspberrypi-kernel-headers samba samba-common-bin tmate sysstat git
 apt-get remove -yqq iptables nftables
 
 # Kernel settings


### PR DESCRIPTION
Raspberry Pi OS (64 bit) doesn't have Git installed by default (or at least mine didn't!). So the script crashed when it came to `git clone` later on. Adding the `git` command as a required tool to install will remove 
this hurdle for some people, and for those that already have it - nothing changes.
